### PR TITLE
fix: recording failures under Arch Linux

### DIFF
--- a/src/views/recordPage.cpp
+++ b/src/views/recordPage.cpp
@@ -225,7 +225,7 @@ void RecordPage::startRecord()
         QString codec;
         QString audioContainer;
         for (auto it : supportCodecList) {
-            if (it.contains("audio/mpeg")) {
+            if (it.contains("audio/mpeg, mpegversion=(int)1, layer=(int)3")) {
                 codec = it;
                 break;
             }


### PR DESCRIPTION
In Arch Linux with Qt 5.15, mp4 was selected and resulted in an
incompatible combination:

```
2020-06-29, 03:38:57.069 [Debug  ] [                                                         0] startRecord: codec-> "audio/mpeg, mpegversion=(int)4"  container: "audio/mpeg, mpegversion=(int)1"
2020-06-29, 03:38:57.069 [Debug  ] [                                                         0] startRecord: codec-> "audio/mpeg, mpegversion=(int)4"  container: "audio/mpeg, mpegversion=(int)1"
2020-06-29, 03:38:57.075 [Warning] [                                                         0] QMediaRecorder::FormatError : Failed to build media capture pipeline.
2020-06-29, 03:38:57.075 [Warning] [                                                         0] QMediaRecorder::FormatError : Failed to build media capture pipeline.
2020-06-29, 03:38:57.076 [Error  ] [                                                         0] Recording error happed:****** QMediaRecorder::FormatError --> "Failed to build media capture pipeline."
2020-06-29, 03:38:57.076 [Error  ] [                                                         0] Recording error happed:****** QMediaRecorder::FormatError --> "Failed to build media capture pipeline."
```

Force mp3 here fixes the issue and makes it record mp3 normally.